### PR TITLE
species params added to form so that a newly created pet will not hav…

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -97,6 +97,6 @@ class PetsController < ApplicationController
 
   def pet_params
     # update to "photos: []"" when doing has many attached photos
-    params.require(:pet).permit(:name, :age, :breed, :age, :location, :sex, :size, :needs_garden, :photo)
+    params.require(:pet).permit(:name, :age, :breed, :age, :location, :sex, :size, :needs_garden, :photo, :species)
   end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -3,6 +3,7 @@ class Pet < ApplicationRecord
   belongs_to :user
   geocoded_by :location
   validates :breed, presence: true
+  validates :species, presence: true
   after_validation :geocode, if: :will_save_change_to_location?
   has_many :applications
     has_many :favourites


### PR DESCRIPTION
-pet species validation added so a pet species must be present on creation (if its not it will break the homepage)
-added to the params also so that the form accepts the species input when creating