### PR TITLE
application chatbox links changed to link_to, this did not work with …

### DIFF
--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -176,7 +176,7 @@
                         <br>
                           <p>APPLICATION APPROVED</p>
                             <h2 class="app-card-text"><%= @pet.name %></h2>
-                              <%= button_to("Message #{@pet.name}'s owner", application_path(application), :class => "delete-fav-btn") %>
+                              <%= link_to "Message #{@pet.name}'s owner", application_path(application), :class => "delete-fav-btn" %>
                   <% elsif application.validated && application.approved === false %>
                       <%= image_tag "app-denied.png", class: "app-icon" %>
                         <br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -125,7 +125,9 @@
                                             <div align="center">
                                               <% if pet_app.approved %>
                                                 <h3><%= "You have approved #{pet_app.user.name}'s application!" %></h3>
-                                                  <%= link_to "Start messaging!", application_path(pet_app), class: 'delete-fav-btn' %>
+                                                  <div align="center">
+                                                    <%= link_to "Start messaging!", application_path(pet_app), class: 'delete-fav-btn' %>
+                                                  </div>
                                               <% else %>
                                                 <%= link_to "Review this application", pet_path(pet_app.pet), class: 'delete-fav-btn' %>
                                               <% end %>
@@ -158,7 +160,9 @@
                                                                       <br>
                                                                         <p>APPLICATION APPROVED</p>
                                                                           <h2 class="app-card-text"><%= pet_app.pet.name %></h2>
-                                                                            <%= button_to("Message #{pet_app.pet.name}'s owner", application_path(pet_app), :class => "delete-fav-btn") %>
+                                                                            <div align='center'>
+                                                                              <%= link_to "Message #{pet_app.pet.name}'s owner", application_path(pet_app), :class => "delete-fav-btn" %>
+                                                                            </div>
                                                                   <% else %>
                                                                     <%= image_tag "app-denied.png", class: "app-icon" %>
                                                                       <br>


### PR DESCRIPTION
-links_to put within their own divs to make them clickable
-links_to also changed from button_to (this was not working correctly)
- links_to can be used unilaterally instead of button_to when needed because they can have button classes on them 